### PR TITLE
v-cloak with logic to avoid pre-render-spa-plugin breaking it

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -28,9 +28,19 @@
     <link rel="canonical" href="https://kravse.dev" />
     <link rel="icon" type="image/png" href="./favicon.png" width=32px>
     <title><%= htmlWebpackPlugin.options.title %></title>
+    <style type="text/css">
+      [v-cloak] {
+        display:none !important;
+      }
+    </style>
   </head>
   <body>
     <noscript>
+      <style type="text/css">
+        [v-cloak] {
+          display: block !important;
+        }
+      </style>
       <div class="noscript-msg">
         <h2 class="h3">Concerned about privacy? Me too.</h2>
         <p>This website doesn't track you, serve ads, or make requests to external APIs or resources. Enabling JavaScript will allow you to see some cool local animations and interactions.</p>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <div id="app" :class="[overlay ? 'stuck' : '']">
+  <div v_cloak id="app" :class="[overlay ? 'stuck' : '']">
     <div class="app-inner">
       <router-view/>
       <site-footer/>

--- a/vue.config.js
+++ b/vue.config.js
@@ -24,6 +24,7 @@ if (process.env.NODE_ENV == 'production') {
     // Required - Routes to render.
     routes: ['/', '/work-history'],
     postProcess(renderedRoute) {
+      renderedRoute.html = renderedRoute.html.replace(/v_cloak/g, "v-cloak")
       renderedRoute.html = renderedRoute.html.replace(/jared\@kravse\.dev/g, `Jared AT kravse DOT dev`)
       return renderedRoute
     },


### PR DESCRIPTION
If you use prerender-spa-plugin with v-cloak, it seems like the plugin will actually strip the vcloak from the document rendering it useless. This PR introduces `v_cloak` which Vue ignores, and then after the plugin is done rendering the page it replaces `v_cloak` with `v-cloak` which vue understands. On pageload in the browser v-cloak will now work as expected.

Also added some styles to `<noscript>` to disable vcloak if no scripts are being run. 